### PR TITLE
Let environment define CC variable. not Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 DESTDIR=
 PREFIX=/usr
 CFLAGS=-Wall -O3
-CC=gcc
 OFLAGS=-O1
 W32GCC=i586-mingw32msvc-gcc # sudo apt-get install mingw32 @ debian squeeze
 INSTALL=install


### PR DESCRIPTION
If the Makefile defines the compiler, the environment
is unable to override. When using a compiler besides
'gcc', this leads to issues.

Note that this is similar to the Radamsa project, which does not define
CC in its Makefile and thus can be cross compiled more easily.
