### PR TITLE
Fixed Makefile: owl-lisp-$(OWLVERSION) to owl-$(OWLVERSION)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CFLAGS?=-Wall -O3
 OFLAGS?=-O1
 INSTALL?=install
 OWLVERSION=0.1.10
-OL?=owl-lisp-$(OWLVERSION)/bin/vm owl-lisp-$(OWLVERSION)/fasl/init.fasl
+OL?=owl-$(OWLVERSION)/bin/vm owl-$(OWLVERSION)/fasl/init.fasl
 
 bin/blab: blab.c
 	mkdir -p bin
@@ -65,8 +65,8 @@ uninstall:
 
 get-owl:
 	# fetching and building owl to build radamsa
-	test -d owl-lisp-$(OWLVERSION) || curl -L https://github.com/aoh/owl-lisp/archive/v$(OWLVERSION).tar.gz | tar -zxvf -
-	cd owl-lisp-$(OWLVERSION) && make bin/vm
+	test -d owl-$(OWLVERSION) || curl -L https://github.com/aoh/owl-lisp/archive/v$(OWLVERSION).tar.gz | tar -zxvf -
+	cd owl-$(OWLVERSION) && make bin/vm
 
 .PHONY: install clean test everything uninstall testi get-owl
 


### PR DESCRIPTION
For proper compilation, I believe the Makefile should contain `owl-$(OWLVERSION)`  rather than `owl-lisp-$(OWLVERSION)` (at least I needed that).